### PR TITLE
remove retention policy setting

### DIFF
--- a/infra-as-code/bicep/webapp.bicep
+++ b/infra-as-code/bicep/webapp.bicep
@@ -112,38 +112,22 @@ resource webAppDiagSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
         category: 'AppServiceHTTPLogs'
         categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceConsoleLogs'
         categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceAppLogs'
         categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }

--- a/infra-as-code/bicep/webapp.bicep
+++ b/infra-as-code/bicep/webapp.bicep
@@ -96,10 +96,6 @@ resource appServicePlanDiagSettings 'Microsoft.Insights/diagnosticSettings@2021-
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

* Remove the commented-out code related to the retention policy in diagnostic settings. According to [doc: (Migrate from diagnostic settings storage retention to Azure Storage lifecycle management)](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy?tabs=portal), the retention functionality for diagnostic settings storage is deprecated and cannot be used in new deployments. This change resolves deployment errors like `Diagnostic settings does not support retention for new diagnostic settings`.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid

- The template deploys successfully without any errors.
- Diagnostic settings are configured correctly without the deprecated retention policy settings.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
- https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy?tabs=portal
- https://github.com/Azure/ResourceModules/issues/3572
- https://github.com/Azure/ResourceModules/pull/3721